### PR TITLE
feat: add timeout to LSP formatting and tab keymaps

### DIFF
--- a/after/plugin/null-ls.lua
+++ b/after/plugin/null-ls.lua
@@ -13,10 +13,7 @@ null_ls.setup({
     on_attach = function(client, bufnr)
         if client.supports_method("textDocument/formatting") then
             vim.keymap.set("n", "<Leader>f", function()
-                vim.lsp.buf.format({ bufnr = vim.api.nvim_get_current_buf() })
-            end, { buffer = bufnr, desc = "[lsp] format" })
-            vim.keymap.set("n", "=", function()
-                vim.lsp.buf.format({ bufnr = vim.api.nvim_get_current_buf() })
+                vim.lsp.buf.format({ timeout_ms = 5000 }) -- Set timeout to 5000ms (5 seconds)
             end, { buffer = bufnr, desc = "[lsp] format" })
 
             -- format on save
@@ -25,7 +22,7 @@ null_ls.setup({
                 buffer = bufnr,
                 group = group,
                 callback = function()
-                    vim.lsp.buf.format({ bufnr = bufnr, async = async })
+                    vim.lsp.buf.format({ bufnr = bufnr, async = async, timeout_ms = 5000 }) -- Set timeout to 5000ms (5 seconds)
                 end,
                 desc = "[lsp] format on save",
             })
@@ -33,10 +30,10 @@ null_ls.setup({
 
         if client.supports_method("textDocument/rangeFormatting") then
             vim.keymap.set("x", "<Leader>f", function()
-                vim.lsp.buf.format({ bufnr = vim.api.nvim_get_current_buf() })
+                vim.lsp.buf.format({ bufnr = vim.api.nvim_get_current_buf(), timeout_ms = 5000 }) -- Set timeout to 5000ms (5 seconds)
             end, { buffer = bufnr, desc = "[lsp] format" })
             vim.keymap.set("n", "=", function()
-                vim.lsp.buf.format({ bufnr = vim.api.nvim_get_current_buf() })
+                vim.lsp.buf.format({ bufnr = vim.api.nvim_get_current_buf(), timeout_ms = 5000 }) -- Set timeout to 5000ms (5 seconds)
             end, { buffer = bufnr, desc = "[lsp] format" })
         end
     end,

--- a/lua/razking/remap.lua
+++ b/lua/razking/remap.lua
@@ -52,3 +52,16 @@ vim.keymap.set("n", "<leader>mr", "<cmd>CellularAutomaton make_it_rain<CR>");
 vim.keymap.set("n", "<leader><leader>", function()
     vim.cmd("so")
 end)
+
+-- Tabs
+-- Map <Esc> in terminal mode to exit to normal mode
+vim.keymap.set("t", "<Esc>", "<C-\\><C-n>", { noremap = true, silent = true })
+-- Map <leader>tn in normal mode to open a new tab
+vim.keymap.set("n", "<leader>tn", function() vim.cmd("tabnew") end)
+-- Map <leader>tc in normal mode to close the current tab
+vim.keymap.set("n", "<leader>tc", function() vim.cmd("tabclose") end)
+-- Map <C-a> in normal mode to prompt for a tab number and switch to that tab
+vim.keymap.set("n", "<C-a>", function()
+    local tab_number = vim.fn.input("Tab number: ")
+    vim.cmd(tab_number .. "tabnext")
+end)


### PR DESCRIPTION
- Set timeout to 5000ms (5 seconds) for LSP formatting functions
- Add keymaps for tab management:
  - <Esc> in terminal mode to exit to normal mode
  - <leader>tn to open a new tab
  - <leader>tc to close the current tab
  - <C-a> to prompt for a tab number and switch to that tab